### PR TITLE
add options to allow certain hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ function Counter() {
 }
 ```
 
+## Options
+
+While it is not recommended, the `prefer-custom-hooks` rule does support an `allow` list as an option. It can be set up like so:
+
+```
+{
+  plugins: ['@kyleshevlin'],
+  rules: [
+    "@kyleshevlin/prefer-custom-hooks": ["error", { "allow": ["useMemo"] }]
+  ]
+}
+```
+
+In this particular setup, using `useMemo` inside of a React component will **not** result in an ESLint error.
+
+It is recommended that you use the `allow` option sparingly. It is likely wiser to use the occasional `eslint-disable` than to allow a particular hook throughout your project.
+
 ## Further Reading
 
 I discuss this concept in depth in my [useEncapsulation](https://kyleshevlin.com/use-encapsulation) blog post.

--- a/__tests__/prefer-custom-hooks.js
+++ b/__tests__/prefer-custom-hooks.js
@@ -1,5 +1,6 @@
 const rule = require('../rules/prefer-custom-hooks')
 const { REACT_HOOKS } = require('../src/constants')
+const { difference } = require * '../src/utils'
 const RuleTester = require('eslint').RuleTester
 
 const rt = new RuleTester({
@@ -33,6 +34,22 @@ rt.run('prefer-custom-hooks', rule, {
     ...HOOKS.map(hook => inArrowFunctionCustomHook(`React.${hook}`)),
     inFunctionComponent('useCustomHook'),
     inArrowFunctionComponent('useCustomHook'),
+    {
+      code: inFunctionComponent('useMemo'),
+      options: [{ allow: ['useMemo'] }],
+    },
+    {
+      code: inFunctionComponent('React.useMemo'),
+      options: [{ allow: ['useMemo'] }],
+    },
+    {
+      code: inArrowFunctionComponent('useMemo'),
+      options: [{ allow: ['useMemo'] }],
+    },
+    {
+      code: inArrowFunctionComponent('React.useMemo'),
+      options: [{ allow: ['useMemo'] }],
+    },
   ],
   invalid: [
     ...HOOKS.map(hook => ({
@@ -51,5 +68,10 @@ rt.run('prefer-custom-hooks', rule, {
       code: inArrowFunctionComponent(`React.${hook}`),
       errors: [expectedError],
     })),
+    {
+      code: 'function Comp() { useMemo(); useEffect(); return null; }',
+      options: [{ allow: ['useMemo'] }],
+      errors: [expectedError],
+    },
   ],
 })

--- a/rules/prefer-custom-hooks.js
+++ b/rules/prefer-custom-hooks.js
@@ -1,4 +1,5 @@
 const { HOOK_PATTERN, REACT_HOOKS } = require('../src/constants')
+const { difference } = require('../src/utils')
 
 function getHookParent(node) {
   if (node.type === 'Program') return
@@ -22,9 +23,13 @@ module.exports = {
     type: 'suggestion',
   },
   create(context) {
+    const options = context.options[0] || { allow: [] }
+    const allowedHooks = new Set(options.allow)
+    const hooksToCheck = difference(REACT_HOOKS, allowedHooks)
+
     return {
       Identifier(node) {
-        if (REACT_HOOKS.has(node.name)) {
+        if (hooksToCheck.has(node.name)) {
           const hookParent = getHookParent(node)
 
           if (hookParent && !HOOK_PATTERN.test(hookParent.id.name)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,15 @@
+function difference(a, b) {
+  const result = new Set(a)
+
+  for (const item of b) {
+    if (a.has(item)) {
+      result.delete(item)
+    }
+  }
+
+  return result
+}
+
+module.exports = {
+  difference,
+}


### PR DESCRIPTION
Fixes #1 

This PR adds the ability to add an `allow` list of hooks to the ESLint rule config options